### PR TITLE
Fix in-doc search not working when stopword is in title

### DIFF
--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
@@ -83,19 +83,11 @@ describe('stopword-testing', () => {
     jest.clearAllMocks();
   });
 
-  it('test with stop words', async () => {
-    // Add another test case for builds-at-seek, really wondering why cannot reproduce
-    // const mockDocuments = [
-    //   {
-    //     title: 'discover-and-career-services',
-    //     text: 'discover-and-career-services',
-    //     location: 'test/location',
-    //   },
-    // ];
+  it('test with stop word', async () => {
     const mockDocuments = [
       {
-        title: 'builds-at-seek',
-        text: 'builds-at-seek',
+        title: 'a home',
+        text: 'mary had a little lamb at home',
         location: 'test/location',
       },
     ];
@@ -106,34 +98,56 @@ describe('stopword-testing', () => {
       .withDocuments(mockDocuments)
       .execute();
 
-    // const mockedSearchResult = await testLunrSearchEngine.query({
-    //   term: 'discover',
-    //   filters: {},
-    // });
     const mockedSearchResult = await testLunrSearchEngine.query({
-      term: 'builds-at-seek',
-      filters: {},
+      term: 'mary',
+      filters: {
+        title: 'a home',
+      },
     });
 
-    // expect(mockedSearchResult).toMatchObject({
-    //   results: [
-    //     {
-    //       document: {
-    //         title: 'discover-and-career-services',
-    //         text: 'discover-and-career-services',
-    //         location: 'test/location',
-    //       },
-    //       rank: 1,
-    //     },
-    //   ],
-    //   nextPageCursor: undefined,
-    // });
     expect(mockedSearchResult).toMatchObject({
       results: [
         {
           document: {
-            title: 'builds-at-seek',
-            text: 'builds-at-seek',
+            title: 'a home',
+            text: 'mary had a little lamb at home',
+            location: 'test/location',
+          },
+          rank: 1,
+        },
+      ],
+      nextPageCursor: undefined,
+    });
+  });
+
+  it('test with stop word connected with dash', async () => {
+    const mockDocuments = [
+      {
+        title: 'a-home',
+        text: 'mary had a little lamb at home',
+        location: 'test/location',
+      },
+    ];
+
+    const indexer = await getActualIndexer(testLunrSearchEngine, 'test-index');
+
+    await TestPipeline.withSubject(indexer)
+      .withDocuments(mockDocuments)
+      .execute();
+
+    const mockedSearchResult = await testLunrSearchEngine.query({
+      term: 'mary',
+      filters: {
+        title: 'a-home',
+      },
+    });
+
+    expect(mockedSearchResult).toMatchObject({
+      results: [
+        {
+          document: {
+            title: 'a-home',
+            text: 'mary had a little lamb at home',
             location: 'test/location',
           },
           rank: 1,

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
@@ -75,89 +75,6 @@ const getActualIndexer = (engine: SearchEngine, index: string) => {
   return engine.getIndexer(index);
 };
 
-describe('stopword-testing', () => {
-  let testLunrSearchEngine: SearchEngine;
-
-  beforeEach(() => {
-    testLunrSearchEngine = new LunrSearchEngine({ logger: getVoidLogger() });
-    jest.clearAllMocks();
-  });
-
-  it('test with stop word', async () => {
-    const mockDocuments = [
-      {
-        title: 'a home',
-        text: 'mary had a little lamb at home',
-        location: 'test/location',
-      },
-    ];
-
-    const indexer = await getActualIndexer(testLunrSearchEngine, 'test-index');
-
-    await TestPipeline.withSubject(indexer)
-      .withDocuments(mockDocuments)
-      .execute();
-
-    const mockedSearchResult = await testLunrSearchEngine.query({
-      term: 'mary',
-      filters: {
-        title: 'a home',
-      },
-    });
-
-    expect(mockedSearchResult).toMatchObject({
-      results: [
-        {
-          document: {
-            title: 'a home',
-            text: 'mary had a little lamb at home',
-            location: 'test/location',
-          },
-          rank: 1,
-        },
-      ],
-      nextPageCursor: undefined,
-    });
-  });
-
-  it('test with stop word connected with dash', async () => {
-    const mockDocuments = [
-      {
-        title: 'a-home',
-        text: 'mary had a little lamb at home',
-        location: 'test/location',
-      },
-    ];
-
-    const indexer = await getActualIndexer(testLunrSearchEngine, 'test-index');
-
-    await TestPipeline.withSubject(indexer)
-      .withDocuments(mockDocuments)
-      .execute();
-
-    const mockedSearchResult = await testLunrSearchEngine.query({
-      term: 'mary',
-      filters: {
-        title: 'a-home',
-      },
-    });
-
-    expect(mockedSearchResult).toMatchObject({
-      results: [
-        {
-          document: {
-            title: 'a-home',
-            text: 'mary had a little lamb at home',
-            location: 'test/location',
-          },
-          rank: 1,
-        },
-      ],
-      nextPageCursor: undefined,
-    });
-  });
-});
-
 describe('LunrSearchEngine', () => {
   let testLunrSearchEngine: SearchEngine;
 
@@ -1172,6 +1089,126 @@ describe('parseHighlightFields', () => {
     ).toEqual({
       foo: '<>abc</> <>def</>',
       bar: 'ghi <>jkl</>',
+    });
+  });
+});
+
+describe('stopword testing', () => {
+  let testLunrSearchEngine: SearchEngine;
+
+  beforeEach(() => {
+    testLunrSearchEngine = new LunrSearchEngine({ logger: getVoidLogger() });
+    jest.clearAllMocks();
+  });
+
+  it('test with stopword in title', async () => {
+    const mockDocuments = [
+      {
+        title: 'a home',
+        text: 'mary had a little lamb at home',
+        location: 'test/location',
+      },
+    ];
+
+    const indexer = await getActualIndexer(testLunrSearchEngine, 'test-index');
+
+    await TestPipeline.withSubject(indexer)
+      .withDocuments(mockDocuments)
+      .execute();
+
+    const mockedSearchResult = await testLunrSearchEngine.query({
+      term: 'mary',
+      filters: {
+        title: 'a home',
+      },
+    });
+
+    expect(mockedSearchResult).toMatchObject({
+      results: [
+        {
+          document: {
+            title: 'a home',
+            text: 'mary had a little lamb at home',
+            location: 'test/location',
+          },
+          rank: 1,
+        },
+      ],
+      nextPageCursor: undefined,
+    });
+  });
+
+  it('test with stopword connected with dash', async () => {
+    const mockDocuments = [
+      {
+        title: 'a-home',
+        text: 'mary had a little lamb at home',
+        location: 'test/location',
+      },
+    ];
+
+    const indexer = await getActualIndexer(testLunrSearchEngine, 'test-index');
+
+    await TestPipeline.withSubject(indexer)
+      .withDocuments(mockDocuments)
+      .execute();
+
+    const mockedSearchResult = await testLunrSearchEngine.query({
+      term: 'mary',
+      filters: {
+        title: 'a-home',
+      },
+    });
+
+    expect(mockedSearchResult).toMatchObject({
+      results: [
+        {
+          document: {
+            title: 'a-home',
+            text: 'mary had a little lamb at home',
+            location: 'test/location',
+          },
+          rank: 1,
+        },
+      ],
+      nextPageCursor: undefined,
+    });
+  });
+
+  it('test with only stop word in title', async () => {
+    const mockDocuments = [
+      {
+        title: 'a',
+        text: 'mary had a little lamb at home',
+        location: 'test/location',
+      },
+    ];
+
+    const indexer = await getActualIndexer(testLunrSearchEngine, 'test-index');
+
+    await TestPipeline.withSubject(indexer)
+      .withDocuments(mockDocuments)
+      .execute();
+
+    const mockedSearchResult = await testLunrSearchEngine.query({
+      term: 'mary',
+      filters: {
+        title: 'a',
+      },
+    });
+
+    expect(mockedSearchResult).toMatchObject({
+      results: [
+        {
+          document: {
+            title: 'a',
+            text: 'mary had a little lamb at home',
+            location: 'test/location',
+          },
+          rank: 1,
+        },
+      ],
+      nextPageCursor: undefined,
     });
   });
 });

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
@@ -75,6 +75,75 @@ const getActualIndexer = (engine: SearchEngine, index: string) => {
   return engine.getIndexer(index);
 };
 
+describe('stopword-testing', () => {
+  let testLunrSearchEngine: SearchEngine;
+
+  beforeEach(() => {
+    testLunrSearchEngine = new LunrSearchEngine({ logger: getVoidLogger() });
+    jest.clearAllMocks();
+  });
+
+  it('test with stop words', async () => {
+    // Add another test case for builds-at-seek, really wondering why cannot reproduce
+    // const mockDocuments = [
+    //   {
+    //     title: 'discover-and-career-services',
+    //     text: 'discover-and-career-services',
+    //     location: 'test/location',
+    //   },
+    // ];
+    const mockDocuments = [
+      {
+        title: 'builds-at-seek',
+        text: 'builds-at-seek',
+        location: 'test/location',
+      },
+    ];
+
+    const indexer = await getActualIndexer(testLunrSearchEngine, 'test-index');
+
+    await TestPipeline.withSubject(indexer)
+      .withDocuments(mockDocuments)
+      .execute();
+
+    // const mockedSearchResult = await testLunrSearchEngine.query({
+    //   term: 'discover',
+    //   filters: {},
+    // });
+    const mockedSearchResult = await testLunrSearchEngine.query({
+      term: 'builds-at-seek',
+      filters: {},
+    });
+
+    // expect(mockedSearchResult).toMatchObject({
+    //   results: [
+    //     {
+    //       document: {
+    //         title: 'discover-and-career-services',
+    //         text: 'discover-and-career-services',
+    //         location: 'test/location',
+    //       },
+    //       rank: 1,
+    //     },
+    //   ],
+    //   nextPageCursor: undefined,
+    // });
+    expect(mockedSearchResult).toMatchObject({
+      results: [
+        {
+          document: {
+            title: 'builds-at-seek',
+            text: 'builds-at-seek',
+            location: 'test/location',
+          },
+          rank: 1,
+        },
+      ],
+      nextPageCursor: undefined,
+    });
+  });
+});
+
 describe('LunrSearchEngine', () => {
   let testLunrSearchEngine: SearchEngine;
 

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -114,11 +114,16 @@ export class LunrSearchEngine implements SearchEngine {
 
             // Require that the given field has the given value
             if (['string', 'number', 'boolean'].includes(typeof value)) {
-              // TODO
-              q.term(lunr.tokenizer(value?.toString()), {
-                presence: lunr.Query.presence.REQUIRED,
-                fields: [field],
-              });
+              q.term(
+                lunr
+                  .tokenizer(value?.toString())
+                  .map(lunr.stopWordFilter)
+                  .filter(element => element !== undefined),
+                {
+                  presence: lunr.Query.presence.REQUIRED,
+                  fields: [field],
+                },
+              );
             } else if (Array.isArray(value)) {
               // Illustrate how multi-value filters could work.
               // But warn that Lurn supports this poorly.

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -114,6 +114,7 @@ export class LunrSearchEngine implements SearchEngine {
 
             // Require that the given field has the given value
             if (['string', 'number', 'boolean'].includes(typeof value)) {
+              // TODO
               q.term(lunr.tokenizer(value?.toString()), {
                 presence: lunr.Query.presence.REQUIRED,
                 fields: [field],


### PR DESCRIPTION
Local PR to reproduce and fix on stop-word searches in `title` and/or `text` field.